### PR TITLE
Delete the endpoint (manually or scheduled) in StableDiffusionInf2.ipynb

### DIFF
--- a/14_SageMakerMisc/02_StableDiffusionInf2/StableDiffusionInf2.ipynb
+++ b/14_SageMakerMisc/02_StableDiffusionInf2/StableDiffusionInf2.ipynb
@@ -395,8 +395,7 @@
    "source": [
     "import time\n",
     "\n",
-    "last_cell_timestamp = time.time()\n",
-    "autodelete_timer = None"
+    "last_cell_timestamp = time.time()"
    ]
   },
   {
@@ -435,6 +434,20 @@
     "        print(e)\n",
     "        pass\n",
     "    print(\"Endpoint has been deleted.\")\n",
+    "    \n",
+    "def schedule_auto_delete():\n",
+    "    global auto_delete_timer\n",
+    "    try:\n",
+    "        print(\"Cancelling previous timer...\")\n",
+    "        auto_delete_timer.cancel()\n",
+    "    except NameError:\n",
+    "        print(\"Timer hasn't been yet defined.\")\n",
+    "        print(f\"Scheduling the automatic deletion in {auto_delete_hours} hours.\")\n",
+    "    else:\n",
+    "        print(\"Timer is cancelled.\")\n",
+    "        print(f\"Re-scheduling the automatic deletion in {auto_delete_hours} hours.\")\n",
+    "    auto_delete_timer = threading.Timer(auto_delete_hours * 60 * 60, delete_endpoint)\n",
+    "    auto_delete_timer.start()    \n",
     "\n",
     "print(\"Checking notebook for automated run...\")\n",
     "print(f\"Seconds since last cell exectution: {seconds_since_last_cell_timestamp}\")\n",
@@ -443,9 +456,7 @@
     "    delete_endpoint()\n",
     "else:\n",
     "    print(\"Cell is executed automatically. Skipping endpoint delete. Don't forget to run the cell again to delete endpoint manually.\")\n",
-    "    print(f\"Scheduling the automatic deletion in {auto_delete_hours} hours...\")\n",
-    "    autodelete_timer = threading.Timer(auto_delete_hours * 60 * 60, delete_endpoint)\n",
-    "    autodelete_timer.start()"
+    "    schedule_auto_delete()"
    ]
   },
   {
@@ -469,14 +480,10 @@
     "print(f\"Seconds since last cell exectution: {seconds_since_last_cell_timestamp}\")\n",
     "\n",
     "if seconds_since_last_cell_timestamp > grace_period_seconds:\n",
-    "    if autodelete_timer:\n",
-    "        print(\"Cancelling previous timer...\")\n",
-    "        autodelete_timer.cancel()\n",
-    "    print(f\"Re-scheduling the automatic deletion in {auto_delete_hours} hours...\")\n",
-    "    autodelete_timer = threading.Timer(auto_delete_hours * 60 * 60, delete_endpoint)\n",
-    "    autodelete_timer.start()\n",
+    "    print(f\"Cell is executed manually. Re-scheduling the timer.\")\n",
+    "    schedule_auto_delete()\n",
     "else:\n",
-    "    print(\"Cell is executed automatically. Skipping re-scheduling.\")"
+    "    print(\"Cell is executed automatically. Skipping re-scheduling. Run the cell again to re-schedule deletion.\")"
    ]
   }
  ],

--- a/14_SageMakerMisc/02_StableDiffusionInf2/StableDiffusionInf2.ipynb
+++ b/14_SageMakerMisc/02_StableDiffusionInf2/StableDiffusionInf2.ipynb
@@ -375,6 +375,109 @@
     "    j += 1\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9398f06-42f5-441e-a206-fe25c45e0003",
+   "metadata": {},
+   "source": [
+    "### Delete the endpoint (manually or scheduled)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f07a61d-4eab-456a-aff2-f8c9cf35eba0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "last_cell_timestamp = time.time()\n",
+    "autodelete_timer = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd8496a3-5efb-4ec4-b286-9158cfa76749",
+   "metadata": {},
+   "source": [
+    "If you're running the notebook with \"Run All Cells\" command, the above cell and the below cell will be executed automatically one by one and the endpoint will stay active for you to experiment with. It will incur additional hourly charges.\n",
+    "\n",
+    "However, if you run the below cell manually again after some time depending on the `grace_period_seconds` variable, the endpoint will be gracefully deleted and no further charges will occur.\n",
+    "\n",
+    "If you forget to delete the endpoint manually, but will keep the notebook kernel instance up and running, the endpoint will be deleted by the background thread depending on the `auto_delete_hours` variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ed390d5-0e34-4cd4-9fad-c4a74f2cdedc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import threading\n",
+    "import botocore.exceptions\n",
+    "\n",
+    "seconds_since_last_cell_timestamp = int(time.time() - last_cell_timestamp)\n",
+    "grace_period_seconds = 30\n",
+    "auto_delete_hours = 4.0\n",
+    "\n",
+    "def delete_endpoint():\n",
+    "    try:\n",
+    "        predictor.delete_endpoint(delete_endpoint_config=False)\n",
+    "    except botocore.exceptions.ClientError as e:\n",
+    "        # Most likely, already deleted\n",
+    "        print(e)\n",
+    "        pass\n",
+    "    print(\"Endpoint has been deleted.\")\n",
+    "\n",
+    "print(\"Checking notebook for automated run...\")\n",
+    "print(f\"Seconds since last cell exectution: {seconds_since_last_cell_timestamp}\")\n",
+    "if seconds_since_last_cell_timestamp > grace_period_seconds:\n",
+    "    print(\"Cell is executed manually. Deleting endpoint.\")\n",
+    "    delete_endpoint()\n",
+    "else:\n",
+    "    print(\"Cell is executed automatically. Skipping endpoint delete. Don't forget to run the cell again to delete endpoint manually.\")\n",
+    "    print(f\"Scheduling the automatic deletion in {auto_delete_hours} hours...\")\n",
+    "    autodelete_timer = threading.Timer(auto_delete_hours * 60 * 60, delete_endpoint)\n",
+    "    autodelete_timer.start()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca2c210f-a6c0-4a05-a6f8-cdf043afe446",
+   "metadata": {},
+   "source": [
+    "If you don't want to delete the endpoint right now, but want to extend the automatic deletion instead, run the below cell manually. The countdown for automatic deletion will start over."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e473b179-f8a2-4d92-a528-a0b3bb3ef3ae",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "seconds_since_last_cell_timestamp = int(time.time() - last_cell_timestamp)\n",
+    "print(f\"Seconds since last cell exectution: {seconds_since_last_cell_timestamp}\")\n",
+    "\n",
+    "if seconds_since_last_cell_timestamp > grace_period_seconds:\n",
+    "    if autodelete_timer:\n",
+    "        print(\"Cancelling previous timer...\")\n",
+    "        autodelete_timer.cancel()\n",
+    "    print(f\"Re-scheduling the automatic deletion in {auto_delete_hours} hours...\")\n",
+    "    autodelete_timer = threading.Timer(auto_delete_hours * 60 * 60, delete_endpoint)\n",
+    "    autodelete_timer.start()\n",
+    "else:\n",
+    "    print(\"Cell is executed automatically. Skipping re-scheduling.\")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adding capability to StableDiffusionInf2.ipynb to automatically or manually delete the endpoint to reduce accidental charges. It gives the following cases:
1/ Manually delete endpoint
2/ Automatically schedule deletion when using "Run all cells" (in 4 hours)
3/ Manually re-schedule deletion (extend the period)